### PR TITLE
feat(bus): rework `HttpRequest` to accept `HttpContent` and generic query strings

### DIFF
--- a/src/SecTester.Bus/Commands/HttpRequest.cs
+++ b/src/SecTester.Bus/Commands/HttpRequest.cs
@@ -6,13 +6,13 @@ namespace SecTester.Bus.Commands;
 
 public record HttpRequest<TResult> : Command<TResult>
 {
-  public string? Body { get; protected init; }
+  public HttpContent? Body { get; protected init; }
   public HttpMethod? Method { get; protected init; }
-  public Dictionary<string, string>? Params { get; protected init; }
+  public IEnumerable<KeyValuePair<string, string>>? Params { get; protected init; }
   public string Url { get; protected init; }
 
-  public HttpRequest(string? url, HttpMethod? method = null, Dictionary<string, string>? @params = null,
-    string? body = null, bool? expectReply = null, int? ttl = null) : base(expectReply, ttl)
+  public HttpRequest(string? url, HttpMethod? method = null, IEnumerable<KeyValuePair<string, string>>? @params = null,
+    HttpContent? body = null, bool? expectReply = null, int? ttl = null) : base(expectReply, ttl)
   {
     Url = url ?? "/";
     Method = method ?? HttpMethod.Get;

--- a/src/SecTester.Bus/README.md
+++ b/src/SecTester.Bus/README.md
@@ -47,9 +47,10 @@ Then you have to create an instance of `HttpRequest` instead of a custom command
 addition to the `Body` that a command accepts by default:
 
 ```csharp
-HttpRequest<object> command = new(url: "/api/v1/repeaters",
+var body = JsonContent.Create(new { Foo = "bar" });
+var command = new HttpRequest<Unit>(url: "/api/v1/repeaters",
   method: HttpMethods.Post,
-  body: @"{""foo"":""bar""}");
+  body: body);
 ```
 
 Once it is done, you can perform a request using `HttpComandDispatcher` as follows:
@@ -61,9 +62,9 @@ var response = await httpDispatcher.execute(command);
 Below you will find a list of parameters that can be used to configure a command:
 
 | Option          | Description                                                                                |
-| --------------- | ------------------------------------------------------------------------------------------ |
+| --------------- |--------------------------------------------------------------------------------------------|
 | `Url`           | Absolute URL or path that will be used for the request. By default, `/`                    |
-| `Method`        | HTTP method that is going to be used when making the request. By default, `GET`            |
+| `Method`        | HTTP method that is going to be used when making the request. By default, `HttpMethod.Get` |
 | `Params`        | Use to set query parameters.                                                               |
 | `Body`          | Message that we want to transmit to the remote service.                                    |
 | `ExpectReply`   | Indicates whether to wait for a reply. By default true.                                    |

--- a/test/SecTester.Bus.Tests/Usings.cs
+++ b/test/SecTester.Bus.Tests/Usings.cs
@@ -2,6 +2,7 @@ global using System;
 global using System.Linq;
 global using System.Net;
 global using System.Net.Http;
+global using System.Net.Http.Json;
 global using System.Text;
 global using System.Text.Json;
 global using System.Text.Json.Serialization;


### PR DESCRIPTION
closes #51