### PR TITLE
feat(scan): add a critical level to the severity

### DIFF
--- a/src/SecTester.Scan/Models/Severity.cs
+++ b/src/SecTester.Scan/Models/Severity.cs
@@ -11,5 +11,8 @@ public enum Severity
   Medium = 2,
 
   [EnumMember(Value = "High")]
-  High = 3
+  High = 3,
+
+  [EnumMember(Value = "Critical")]
+  Critical = 4
 }

--- a/test/SecTester.Bus.Tests/Dispatchers/MessageSerializerTests.cs
+++ b/test/SecTester.Bus.Tests/Dispatchers/MessageSerializerTests.cs
@@ -56,6 +56,7 @@ public class MessageSerializerTests
 
   public static readonly IEnumerable<object[]> SeverityEnumerable = new List<object[]>
   {
+    new object[] { Severity.Critical, @"""Critical""" },
     new object[] { Severity.Medium, @"""Medium""" },
     new object[] { Severity.High, @"""High""" },
     new object[] { Severity.Low, @"""Low""" }

--- a/test/SecTester.Scan.Tests/ScanTests.cs
+++ b/test/SecTester.Scan.Tests/ScanTests.cs
@@ -570,11 +570,11 @@ public class ScanTests : IAsyncDisposable
     // arrange
     _scans.GetScan(ScanId).Returns(new ScanState(scanStatus), new ScanState(scanStatus)
     {
-      IssuesBySeverity = new[] { new IssueGroup(1, Severity.High) }
+      IssuesBySeverity = new[] { new IssueGroup(1, Severity.Critical) }
     });
 
     // act
-    var act = () => _sut.Expect(Severity.Medium);
+    var act = () => _sut.Expect(Severity.Low);
 
     // assert
     await act.Should().NotThrowAsync<Exception>();


### PR DESCRIPTION
Introduce the ability to set the severity threshold to the `Critical` level using the `Threshold` method:

```csharp
scan.Threshold(Severity.Critical);
```

With this implementation, the scan will continue despite the presence of issues with a severity lower than `Critical`, and will only stop for issues of `Critical` severity.

closes #149