### PR TITLE
ci: pin .NET SDK to 6.0.423

### DIFF
--- a/.github/workflows/composite/net/action.yml
+++ b/.github/workflows/composite/net/action.yml
@@ -16,7 +16,7 @@ runs:
       uses: actions/setup-dotnet@v3
       if: runner.os == 'Windows'
       with:
-        dotnet-version: 6.x.x
+        dotnet-version: 6.0.423
 
     - name: Dependency Caching
       uses: actions/cache@v3


### PR DESCRIPTION
Built in `dotnet format` tool considered broken in range [6.0.0 - 6.0.203]( 
https://github.com/nx-dotnet/nx-dotnet/blob/4c19278ce430cfc6409fb736ab50ccd41de31bfa/packages/core/src/executors/format/executor.ts#L46C1-L46C74)
